### PR TITLE
Deploy static site into shared static host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM node:26-bookworm-slim AS build
 WORKDIR /app
-RUN corepack enable
-COPY package.json pnpm-lock.yaml ./
+RUN npm install -g pnpm@10.20.0
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm build
 FROM nginx:1.29-alpine
-COPY --from=build /app/dist /usr/share/nginx/sites/kasperrt.me
+COPY --from=build /app/build /usr/share/nginx/sites/kasperrt.me
 COPY .build/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80


### PR DESCRIPTION
## Summary\n- remove the per-site Docker/nginx image path for kasperrt.me\n- build Astro output directly in GitHub Actions\n- upload the generated static files into the shared static-sites pod/PVC\n\n## Infra dependency\nRequires kasperrt/infra main commit 6e4b469 or newer, which creates the shared static-sites nginx deployment, PVC, service, and ingress.\n\n## Verification\n- pnpm install --frozen-lockfile\n- pnpm build\n- tar -C build -czf /tmp/kasperrt-static-test.tar.gz .\n- terraform -chdir=cluster validate in infra\n- terraform -chdir=cluster plan shows 5 static-sites resources to add, 0 change, 0 destroy