### PR TITLE
Harden self-hosted deploy runner usage

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -8,9 +8,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: prod-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
-    runs-on: [self-hosted, k3s, deployer]
+    environment: production
+    runs-on: [self-hosted, k3s, deployer, kasperrt-kasperrt]
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary\n- require the repo-specific self-hosted runner label for production deploys\n- attach deploy jobs to the production environment\n- add a production concurrency group so deploys for the same ref do not overlap\n\n## Tests\n- workflow-only change